### PR TITLE
Fix publish workflow branch hardcoding bug

### DIFF
--- a/lib/publish.sh
+++ b/lib/publish.sh
@@ -73,7 +73,7 @@ save_draft_progress() {
 Co-Authored-By: Claude <noreply@anthropic.com>"
         
         echo -e "${BLUE}📤 Pushing to remote...${NC}"
-        git push origin main
+        git push origin HEAD
         
         echo -e "${GREEN}✅ Draft progress saved successfully!${NC}"
         echo -e "${BLUE}📊 Word count: $word_count${NC}"
@@ -192,7 +192,7 @@ publish_post() {
 Co-Authored-By: Claude <noreply@anthropic.com>"
     
     echo -e "${BLUE}📤 Pushing to remote...${NC}"
-    git push origin main
+    git push origin HEAD
     
     echo -e "${GREEN}✅ Post published successfully!${NC}"
     echo -e "${GREEN}🚀 GitHub Actions will deploy automatically${NC}"
@@ -251,7 +251,7 @@ delete_draft() {
 Co-Authored-By: Claude <noreply@anthropic.com>"
         
         echo -e "${BLUE}📤 Pushing to remote...${NC}"
-        git push origin main
+        git push origin HEAD
         
         echo -e "${GREEN}✅ Draft deleted and changes pushed!${NC}"
     else


### PR DESCRIPTION
## Summary
Fixes a critical bug in the zwrite publish workflow where `git push origin main` was hardcoded, causing publish failures when working on non-main branches.

## Problem
- Digital Sovereignty was on branch `draft/20250917` with 10 unpushed commits
- Publish script tried to push to `main` instead of current branch
- Result: "Everything up-to-date" message and no actual push to remote
- No PR was created because commits never reached the remote

## Solution
- Changed `git push origin main` to `git push origin HEAD` in all functions
- Now pushes to whatever branch is currently checked out
- Affects: `save_draft_progress()`, `publish_post()`, and `delete_draft()`

## Test plan
- [x] Fixed Digital Sovereignty publish issue - 10 commits successfully pushed
- [x] Verified Sunday Blender continues to work (was unaffected)
- [ ] Test with future publishes on various branch names

🤖 Generated with [Claude Code](https://claude.ai/code)